### PR TITLE
Don't reset stdin in editor main loop

### DIFF
--- a/src/editor/edit.rs
+++ b/src/editor/edit.rs
@@ -19,7 +19,6 @@ impl super::Editor {
 
         loop {
             // Loop for a key press
-            stdin!().reset(false).unwrap();
             boot_services!()
                 .wait_for_event(
                     [


### PR DESCRIPTION
Fixes shift and caps lock keys not working properly